### PR TITLE
Use the generic/ubuntu1604 image.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,6 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "velocity42/xenial64"
+  config.vm.box = "generic/ubuntu1604"
   config.vm.provision "shell", :path => "provision.sh", privileged: false
 end


### PR DESCRIPTION
Compared to the custom "velocity42/xenial64" image, the build process
for "generic/ubuntu1604" is well-documented and reproducible and the
image is regularly updated to match latest security packages and updates
from Ubuntu.
Furthermore, the image is available for more providers, including libvirt
and Hyper-V.