### PR TITLE
Fix error handling in builder Prepare()

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -112,7 +112,7 @@ func (b *Builder) Prepare(cfgs ...interface{}) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	var errs error
+	var errs *packer.MultiError
 	var warnings []string
 	isoWarnings, isoErrs := b.config.ISOConfig.Prepare(&b.config.ctx)
 	warnings = append(warnings, isoWarnings...)
@@ -182,7 +182,10 @@ func (b *Builder) Prepare(cfgs ...interface{}) ([]string, error) {
 		b.config.QemuBinary = path
 	}
 
-	return warnings, errs
+	if errs != nil && len(errs.Errors) > 0 {
+		return warnings, errs
+	}
+	return warnings, nil
 }
 
 type wrappedCommandTemplate struct {


### PR DESCRIPTION
fixes #5 

In order for Prepare() to be considered "successful", the returned
error must be nil. However, after calling packer.MultiErrorAppend,
the errs variable is not nil anymore, always resulting in a failed
image build.

This patch follows the pattern found in other builder plugins to test
whether the packer.MultiError contains any errors. If so, the errors
are returned, if not, a literal nil is returned.