### PR TITLE
Fix an issue where adding partition devmappings before listing them would result in the listing on non-existing devmappings, even though devmappings were created.

### DIFF
--- a/pkg/builder/step_map_image.go
+++ b/pkg/builder/step_map_image.go
@@ -21,14 +21,17 @@ func (s *stepMapImage) Run(_ context.Context, state multistep.StateBag) multiste
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Message(fmt.Sprintf("mappping %s", image))
-	if run(state, fmt.Sprintf(
-		"kpartx -s -a %s",
-		image)) != nil {
-		return multistep.ActionHalt
-	}
+	// if run(state, fmt.Sprintf(
+	//	"kpartx -s -a %s",
+	//	image)) != nil {
+	//	return multistep.ActionHalt
+	//}
 
-	out, err := exec.Command("kpartx", "-l", image).CombinedOutput()
-	ui.Say(fmt.Sprintf("kpartx -l: %s", string(out)))
+	out, err := exec.Command("kpartx", "-s", "-a", "-v", image).CombinedOutput()
+	ui.Say(fmt.Sprintf("kpartx -s -a -v %s", image))
+
+	// out, err := exec.Command("kpartx", "-l", image).CombinedOutput()
+	// ui.Say(fmt.Sprintf("kpartx -l: %s", string(out)))
 	if err != nil {
 		ui.Error(fmt.Sprintf("error kaprts -l %v: %s", err, string(out)))
 		s.Cleanup(state)
@@ -38,8 +41,14 @@ func (s *stepMapImage) Run(_ context.Context, state multistep.StateBag) multiste
 	// get the loopback device for the partitions
 	// kpartx -l output looks like this:
 	/*
-		loop2p1 : 0 85045 /dev/loop2 8192
-		loop2p2 : 0 3534848 /dev/loop2 94208
+	loop2p1 : 0 85045 /dev/loop2 8192
+	loop2p2 : 0 3534848 /dev/loop2 94208
+	*/
+	/*
+	  kpartx -a -v output looks like this:
+
+		add map loop20p1 (254:22): 0 88262 linear 7:20 8192
+		add map loop20p2 (254:23): 0 3538944 linear 7:20 98304
 	*/
 	lines := strings.Split(string(out), "\n")
 
@@ -49,13 +58,13 @@ func (s *stepMapImage) Run(_ context.Context, state multistep.StateBag) multiste
 		if line == "" {
 			continue
 		}
-		device := strings.Split(string(line), " : ")
-		if len(device) != 2 {
+		device := strings.Split(string(line), " ")
+		if len(device) != 9 {
 			ui.Error("bad kpartx output: " + string(out))
 			s.Cleanup(state)
 			return multistep.ActionHalt
 		}
-		partitions = append(partitions, "/dev/mapper/"+device[0])
+		partitions = append(partitions, "/dev/mapper/"+device[2])
 	}
 
 	state.Put(s.ResultKey, partitions)


### PR DESCRIPTION
Fix an issue where adding partition devmappings before listing them would result in the listing on non-existing devmappings, even though devmappings were created.

When running `kpartx -a`, /dev/loop3 might be created. Afterwards, `kpartx -l` would return /dev/loop4 instead, breaking the mounting process.

Signed-off-by: Kalman Olah <kalman@inuits.eu>