### PR TITLE
update packer and allow easy reprovisioning

### DIFF
--- a/provision-build-env.sh
+++ b/provision-build-env.sh
@@ -45,9 +45,9 @@ export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 go get -u github.com/golang/dep/cmd/dep
 
 # Download and install packer
-wget https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_linux_amd64.zip \
-    -q -O /tmp/packer_1.2.1_linux_amd64.zip
+wget https://releases.hashicorp.com/packer/1.2.4/packer_1.2.4_linux_amd64.zip \
+    -q -O /tmp/packer_1.2.4_linux_amd64.zip
 pushd /tmp
-unzip -u packer_1.2.1_linux_amd64.zip
+unzip -u packer_1.2.4_linux_amd64.zip
 sudo cp packer /usr/local/bin
 popd

--- a/provision-build-env.sh
+++ b/provision-build-env.sh
@@ -45,6 +45,7 @@ export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 go get -u github.com/golang/dep/cmd/dep
 
 # Download and install packer
+[[ -e /tmp/packer ]] && rm /tmp/packer
 wget https://releases.hashicorp.com/packer/1.2.4/packer_1.2.4_linux_amd64.zip \
     -q -O /tmp/packer_1.2.4_linux_amd64.zip
 pushd /tmp


### PR DESCRIPTION
- update packer to 1.2.4
- allow packer to be updated via `vagrant provision`

if a packer binary is still left in /tmp it will now be deleted.