### PR TITLE
Skip mounting partitions given empty mountpoints.

### DIFF
--- a/pkg/builder/step_mount_image.go
+++ b/pkg/builder/step_mount_image.go
@@ -51,6 +51,9 @@ func (s *stepMountImage) Run(_ context.Context, state multistep.StateBag) multis
 	sort.Slice(mountsAndPartitions, func(i, j int) bool { return mountsAndPartitions[i].mnt < mountsAndPartitions[j].mnt })
 
 	for _, mntAndPart := range mountsAndPartitions {
+		if mntAndPart.mnt == "" {
+			continue
+		}
 
 		mntpnt := filepath.Join(s.tempdir, mntAndPart.mnt)
 


### PR DESCRIPTION
This is useful for the rock64 image https://github.com/ayufan-rock64/linux-build/releases/download/0.7.8/stretch-minimal-rock64-0.7.8-1061-arm64.img.xz which contains several partitions that shouldn't/can't be mounted during packer build.  With this patch and the following config it works:

```
      qemu_binary: "qemu-aarch64-static",
      image_mounts: ["", "", "", "", "", "/boot", "/"],
```