### PR TITLE
Add target_image_size to replace last_partition_extra_size

### DIFF
--- a/example.json
+++ b/example.json
@@ -6,7 +6,7 @@
     "iso_url" : "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2017-12-01/2017-11-29-raspbian-stretch-lite.zip",
     "iso_checksum_type":"sha256",
     "iso_checksum":"e942b70072f2e83c446b9de6f202eb8f9692c06e7d92c343361340cc016e0c9f",
-    "last_partition_extra_size" : 1073741824
+    "target_image_size": 4294967296
   }],  
   "provisioners": [
   {

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -28,7 +28,7 @@ func init() {
 	knownArgs = make(map[utils.KnownImageType][]string)
 	knownTypes[utils.RaspberryPi] = []string{"/boot", "/"}
 	knownTypes[utils.BeagleBone] = []string{"/"}
-	knownTypes[utils.Kali] = []string{"/root","/"}
+	knownTypes[utils.Kali] = []string{"/root", "/"}
 	knownArgs[utils.BeagleBone] = []string{"-cpu", "cortex-a8"}
 }
 
@@ -60,6 +60,10 @@ type Config struct {
 	// Should the last partition be extended? this only works for the last partition in the
 	// dos partition table, and ext filesystem
 	LastPartitionExtraSize uint64 `mapstructure:"last_partition_extra_size"`
+	// The target size of the final image. The last partiation will be extended to
+	// fill up this much room. I.e. if the generated image is 256MB and TargetImageSize
+	// is set to 384MB the last partition will be extended with an additional 128MB.
+	TargetImageSize uint64 `mapstructure:"target_image_size"`
 
 	// Qemu binary to use. default is qemu-arm-static
 	QemuBinary string `mapstructure:"qemu_binary"`


### PR DESCRIPTION
This change to the resize logic introduces a new way to specify the
extension of the last partition -- target_image_size. Using this config
parameter users can specify the size of their SD card once and update
the base image without having to recompute last_partition_extra_size.

Users can still use last_partition_extra_size if target_image_size is
not specified. As such this change should be backwards compatible.