### PR TITLE
Replace OutputDir with OutputFile

### DIFF
--- a/pkg/builder/step_copy_image.go
+++ b/pkg/builder/step_copy_image.go
@@ -27,16 +27,16 @@ func (s *stepCopyImage) Run(ctx context.Context, state multistep.StateBag) multi
 	s.ui = state.Get("ui").(packer.Ui)
 	s.ui.Say("Copying source image.")
 
-	imageName := "image"
+	outputDir := filepath.Dir(config.OutputFile)
+	imageName := filepath.Base(config.OutputFile)
 
-	dstfile := filepath.Join(config.OutputDir, imageName)
-	err := s.copy(ctx, state, fromFile, config.OutputDir, imageName)
+	err := s.copy(ctx, state, fromFile, outputDir, imageName)
 	if err != nil {
 		s.ui.Error(fmt.Sprintf("%v", err))
 		return multistep.ActionHalt
 	}
 
-	state.Put(s.ResultKey, dstfile)
+	state.Put(s.ResultKey, config.OutputFile)
 	return multistep.ActionContinue
 }
 


### PR DESCRIPTION
This is so that the output filename can be customised, since currently it's hardcoded to `$OutputDir/image`.

I've kept the old `OutputDir` in there so people's builds don't break and added a deprecation warning. Happy to remove one or the other if you need me to.