### PR TITLE
Multiple upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ With this plugin, you can:
 - Resize the last partition (the filesystem partition in the raspberry pi) in case you need more
   space than the default.
 
-Tested for Raspbian images on built on Ubuntu 17.10. It is based partly on the chroot AWS 
+Tested for Raspbian images on built on Ubuntu 19.10. It is based partly on the chroot AWS
 provisioner, though the code was copied to prevent AWS dependencies.
 
 # How it works?

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,18 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu1604"
-  config.vm.provider :virtualbox do |vb, override|
-    # generic/ubuntu1604 does not come with virtualbox-guest-utils installed even
-    # though a virtualbox flavor exists.
-    # Therefore, override the image for virtualbox provider.
-    override.vm.box = "ubuntu/xenial64"
-    # disable the generation of ubuntu-xenial-16.04-cloudimg-console.log file
-    # https://betacloud.io/get-rid-of-ubuntu-xenial-16-04-cloudimg-console-log/
-    #vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
-  end
+  config.vm.box = "ubuntu/eoan64"
   config.vm.synced_folder "./", "/vagrant", disabled: false
-
   config.vm.provision "build-env", type: "shell", :path => "provision-build-env.sh", privileged: false
   config.vm.provision "packer-builder-arm-image", type: "shell", :path => "provision-packer-builder-arm-image.sh", privileged: false, env: {"GIT_CLONE_URL" => ENV["GIT_CLONE_URL"]}
   config.vm.provision "build-image", type: "shell", :path => "provision-build-image.sh", privileged: false, env: {"PACKERFILE" => ENV["PACKERFILE"]}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/solo-io/packer-builder-arm-image
 
 require (
+	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/packer v1.4.5
 	github.com/rekby/mbr v0.0.0-20151216101307-8c28b6465703
 	github.com/ulikunitz/xz v0.5.5

--- a/provision-build-env.sh
+++ b/provision-build-env.sh
@@ -12,14 +12,24 @@ set -x
 # Update the system
 sudo apt-get update -qq
 
-sudo DEBIAN_FRONTEND=noninteractive apt-get -y --force-yes -qq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+sudo DEBIAN_FRONTEND=noninteractive apt-get \
+  -y \
+  --allow-downgrades \
+  --allow-remove-essential \
+  --allow-change-held-packages \
+ -qq \
+ -o Dpkg::Options::="--force-confdef" \
+ -o Dpkg::Options::="--force-confold" \
+  dist-upgrade
+
+# Provides the add-apt-repository script
 sudo apt-get install -y software-properties-common
 
 # Add the golang repo
-sudo add-apt-repository --yes ppa:gophers/archive
+sudo add-apt-repository --yes ppa:longsleep/golang-backports
+sudo apt-get update
 
 # Install required packages
-sudo apt-get update
 sudo apt-get install -y \
     kpartx \
     qemu-user-static \
@@ -28,27 +38,24 @@ sudo apt-get install -y \
     curl \
     vim \
     unzip \
-    golang-1.9-go \
+    golang-go \
     gcc
 
 # Set GO paths for vagrant user
-echo 'export GOROOT=/usr/lib/go-1.9
+echo 'export GOROOT=/usr/lib/go-1.13
 export GOPATH=$HOME/work
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' | tee -a /home/vagrant/.profile
 
 # Also set them while we work:
-export GOROOT=/usr/lib/go-1.9
+export GOROOT=/usr/lib/go-1.13
 export GOPATH=$HOME/work
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
-# Install go dep
-go get -u github.com/golang/dep/cmd/dep
-
 # Download and install packer
 [[ -e /tmp/packer ]] && rm /tmp/packer
-wget https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip \
-    -q -O /tmp/packer_1.3.5_linux_amd64.zip
-pushd /tmp
-unzip -u packer_1.3.5_linux_amd64.zip
+wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip \
+    -q -O /tmp/packer_1.4.5_linux_amd64.zip
+cd /tmp
+unzip -u packer_1.4.5_linux_amd64.zip
 sudo cp packer /usr/local/bin
-popd
+cd ..

--- a/provision-packer-builder-arm-image.sh
+++ b/provision-packer-builder-arm-image.sh
@@ -11,22 +11,22 @@ set -x
 
 # Now ready to build the plugin
 mkdir -p $GOPATH/src/github.com/solo-io/
-pushd $GOPATH/src/github.com/solo-io/
+cd $GOPATH/src/github.com/solo-io/
+
 # clean up potential residual files from previous builds
 rm -rf packer-builder-arm-image
-if [[ -z "${GIT_CLONE_URL}" ]]; then {
-    cp -a /vagrant packer-builder-arm-image
-} else {
-    git clone ${GIT_CLONE_URL} packer-builder-arm-image
-}; fi
-pushd ./packer-builder-arm-image
+if [[ -z "${GIT_CLONE_URL}" ]]; then
+  cp -a /vagrant packer-builder-arm-image
+else
+  git clone ${GIT_CLONE_URL} packer-builder-arm-image
+fi
+cd packer-builder-arm-image
 go build
 
 # Check if plugin built and copy into place
-if [[ ! -f packer-builder-arm-image ]]; then {
-    echo "Error Plugin failed to build."
-    exit
-} else {
-    cp packer-builder-arm-image /vagrant
-}; fi
-
+if [[ ! -f packer-builder-arm-image ]]; then
+  echo "Error Plugin failed to build."
+  exit
+else
+  cp packer-builder-arm-image /vagrant
+fi

--- a/samples/raspbian_golang.json
+++ b/samples/raspbian_golang.json
@@ -4,9 +4,9 @@
   "builders": [
     {
       "type": "arm-image",
-      "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2017-12-01/2017-11-29-raspbian-stretch-lite.zip",
+      "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip",
       "iso_checksum_type": "sha256",
-      "iso_checksum": "e942b70072f2e83c446b9de6f202eb8f9692c06e7d92c343361340cc016e0c9f",
+      "iso_checksum": "a50237c2f718bd8d806b96df5b9d2174ce8b789eda1f03434ed2213bbca6c6ff",
       "target_image_size": 4294967296
     }
   ],
@@ -14,7 +14,8 @@
     {
       "type": "shell",
       "inline": [
-        "apt-get update && apt-get install -y golang"
+	      "apt-get update",
+	      "apt-get install -y golang"
       ]
     }
   ]


### PR DESCRIPTION
This PR upgrades:
- The Vagrant box to ubuntu/bionic64
- Golang to 1.13
- Packer to 1.4.5
- Raspbian buster lite (2019-09-26)

I have added the ld_preload patch step because these kind of errors were being thrown during the build of the image: https://github.com/ipfs/go-ipfs/issues/4735

I was not able to use the project Vagrant example without these upgrades.