### PR TITLE
Bind mount `/etc/resolv.conf`

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -37,6 +37,7 @@ var (
 		{"bind", "/dev", "/dev"},
 		{"devpts", "devpts", "/dev/pts"},
 		{"binfmt_misc", "binfmt_misc", "/proc/sys/fs/binfmt_misc"},
+		{"bind", "/etc/resolv.conf", "/etc/resolv.conf"},
 	}
 )
 

--- a/pkg/builder/step_mount_extra.go
+++ b/pkg/builder/step_mount_extra.go
@@ -34,11 +34,13 @@ func (s *StepMountExtra) Run(ctx context.Context, state multistep.StateBag) mult
 	for _, mountInfo := range config.ChrootMounts {
 		innerPath := mountPath + mountInfo[2]
 
-		if err := os.MkdirAll(innerPath, 0755); err != nil {
-			err := fmt.Errorf("Error creating mount directory: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
+		if _, err := os.Stat(innerPath); os.IsNotExist(err) {
+			if err := os.MkdirAll(innerPath, 0755); err != nil {
+				err := fmt.Errorf("Error creating mount directory: %s", err)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
 		}
 
 		flags := "-t " + mountInfo[0]


### PR DESCRIPTION
On a particular network my Packer builds are intermittently failing. Mounting `/etc/resolv.conf` fixes the issue and seems to be a common fix to this problem. To test this, I setup a `chroot` manually and ran `for i in $(seq 1 20); do apt-get update -qq 2>&1 | grep -q '^' && echo FAIL || echo PASS; done` with and without `/etc/resolv.conf` mounted. Without `/etc/resolv.conf` mounted the success rate was 40%. With `/etc/resolv.conf` mounted the success rate was 100%.