### PR TITLE
Add github actions workflow to publish docker image to package registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,22 @@
+name: Build and publish docker image to registry
+on:
+  push:
+    branches:
+      - lyftmaster
+    tags:
+      - '*'
+jobs:
+  build-and-publish-docker-image:
+    name: Build and publish docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Publish to Registry
+        uses: elgohr/Publish-Docker-Github-Action@2.8
+        with:
+          name: ${{ github.repository }}/packer-builder-arm
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          tag_names: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build and publish docker image to registry
 on:
   push:
     branches:
-      - lyftmaster
+      - master
     tags:
       - '*'
 jobs:


### PR DESCRIPTION
This change adds a github actions workflow that will publish the docker image to the github package repository `solo-io/packer-builder-arm-image/packer-builder-arm:<tag>` on master, or on tagged releases.