### PR TITLE
Update base images used in sample templates

### DIFF
--- a/contrib/pi-secure-wifi-ssh.json
+++ b/contrib/pi-secure-wifi-ssh.json
@@ -6,10 +6,10 @@
   },
   "builders": [{
     "type": "arm-image",
-    "iso_url" : "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2017-12-01/2017-11-29-raspbian-stretch-lite.zip",
-    "iso_checksum_type":"sha256",
-    "iso_checksum":"e942b70072f2e83c446b9de6f202eb8f9692c06e7d92c343361340cc016e0c9f",
-    "last_partition_extra_size" : 1073741824
+    "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip",
+    "iso_checksum_type": "sha256",
+    "iso_checksum": "12ae6e17bf95b6ba83beca61e7394e7411b45eba7e6a520f434b0748ea7370e8",
+    "last_partition_extra_size": 1073741824
   }],  
   "provisioners": [
     {
@@ -20,7 +20,7 @@
       "type": "shell",
       "inline": [
         "wpa_passphrase \"{{user `wifi_name`}}\" \"{{user `wifi_password`}}\" | sed -e 's/#.*$//' -e '/^$/d' >> /etc/wpa_supplicant/wpa_supplicant.conf"
-        ]
+      ]
     },
     {
       "type": "file",

--- a/samples/kali_golang.json
+++ b/samples/kali_golang.json
@@ -4,9 +4,9 @@
   "builders": [
     {
       "type": "arm-image",
-      "iso_url": "https://images.offensive-security.com/arm-images/kali-linux-2018.4-rpi3-nexmon.img.xz",
+      "iso_url": "https://images.offensive-security.com/arm-images/kali-linux-2020.2a-rpi3-nexmon.img.xz",
       "iso_checksum_type": "sha256",
-      "iso_checksum": "ae953fbbe5d161baab321f5a9cd4e1899789b4e924aee015516db5787f3a16f5"
+      "iso_checksum": "ea6e4ffc142a9216de18119ff97dcb8741f7a69d28ba947eb5bb61b5e5340a0c"
     }
   ],
   "provisioners": [

--- a/samples/raspbian_ansible_chroot.json
+++ b/samples/raspbian_ansible_chroot.json
@@ -5,9 +5,9 @@
   "builders": [
     {
       "type": "arm-image",
-      "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip",
+      "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip",
       "iso_checksum_type": "sha256",
-      "iso_checksum": "a50237c2f718bd8d806b96df5b9d2174ce8b789eda1f03434ed2213bbca6c6ff",
+      "iso_checksum": "12ae6e17bf95b6ba83beca61e7394e7411b45eba7e6a520f434b0748ea7370e8",
       "mount_path": "{{ user `img_mount_path` }}"
     }
   ],

--- a/samples/raspbian_golang.json
+++ b/samples/raspbian_golang.json
@@ -4,9 +4,9 @@
   "builders": [
     {
       "type": "arm-image",
-      "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip",
+      "iso_url": "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip",
       "iso_checksum_type": "sha256",
-      "iso_checksum": "a50237c2f718bd8d806b96df5b9d2174ce8b789eda1f03434ed2213bbca6c6ff",
+      "iso_checksum": "12ae6e17bf95b6ba83beca61e7394e7411b45eba7e6a520f434b0748ea7370e8",
       "target_image_size": 4294967296
     }
   ],


### PR DESCRIPTION
Some of the base OS images in contrib/ and samples/ had fallen out of date.
* Kali 2020.2a
* raspbian buster lite 2020-02-13