### PR TITLE
Fix docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ENV PACKER_VERSION 1.5.5
 
 RUN wget https://github.com/hashicorp/packer/releases/download/nightly/packer_linux_amd64.zip -O /tmp/packer.zip && \
   unzip /tmp/packer.zip -d /bin && \
-  mv /bin/pkg/packer_linux_amd64 /bin/packer && \
   rm /tmp/packer.zip
 WORKDIR /build
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,7 +14,6 @@ ENV PACKER_VERSION 1.5.5
 
 RUN wget https://github.com/hashicorp/packer/releases/download/nightly/packer_linux_amd64.zip -O /tmp/packer.zip && \
   unzip /tmp/packer.zip -d /bin && \
-  mv /bin/pkg/packer_linux_amd64 /bin/packer && \
   rm /tmp/packer.zip
 WORKDIR /build
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ docker run \
   -v ${PWD}/packer_cache:/build/packer_cache \
   -v ${PWD}/output-arm-image:/build/output-arm-image \
   -e PACKER_CACHE_DIR=/build/packer_cache \
-  packer-builder-arm samples/raspbian_golang.json
+  packer-builder-arm build samples/raspbian_golang.json
 ```
 
 ### Option 2: Run the published Docker image


### PR DESCRIPTION
I encountered following error when I run `docker build -t packer-builder-arm .` .
The directory structure of the latest archive of packer seems to be changed.

So I fixed Dockerfile to follow the changing of the directory structure.

```
2020-07-02 10:47:00 (735 KB/s) - '/tmp/packer.zip' saved [30851663/30851663]

Archive:  /tmp/packer.zip
  inflating: /bin/packer
mv: cannot stat '/bin/pkg/packer_linux_amd64': No such file or directory
The command '/bin/sh -c wget https://github.com/hashicorp/packer/releases/download/nightly/packer_linux_amd64.zip -O /tmp/packer.zip &&   unzip /tmp/packer.zip -d /bin &&   mv /bin/pkg/packer_linux_amd64 /bin/packer &&   rm /tmp/packer.zip' returned a non-zero code: 1
```