### PR TITLE
Install plugin to root home

### DIFF
--- a/provision-build-image.sh
+++ b/provision-build-image.sh
@@ -11,8 +11,8 @@ set -e
 # Set to false to disable auto building
 export PACKERFILE=${PACKERFILE:-samples/raspbian_golang.json}
 
-mkdir -p /home/vagrant/.packer.d/plugins
-cp /vagrant/packer-builder-arm-image /home/vagrant/.packer.d/plugins/
+sudo mkdir -p /root/.packer.d/plugins
+sudo cp /vagrant/packer-builder-arm-image /root/.packer.d/plugins/
 
 # Now build the image
 if [[ ! -f /home/vagrant/.packer.d/plugins/packer-builder-arm-image ]]; then {


### PR DESCRIPTION
Since we're running packer as root (with sudo), its expecting plugins to be installed in root's home, not the vagrant user's.
I was experiencing this issue without these changes when running `vagrant provision --provision-with build-image` :

```default: Failed to initialize build 'arm-image': error initializing builder 'arm-image': Unknown builder arm-image```