### PR TITLE
Update base ubuntu image to ubuntu 20 (focal fossa)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/eoan64"
+  config.vm.box = "ubuntu/focal64"
   config.vm.synced_folder "./", "/vagrant", disabled: false
   config.vm.provision "build-env", type: "shell", :path => "provision-build-env.sh", privileged: false
   config.vm.provision "packer-builder-arm-image", type: "shell", :path => "provision-packer-builder-arm-image.sh", privileged: false, env: {"GIT_CLONE_URL" => ENV["GIT_CLONE_URL"]}


### PR DESCRIPTION
The eoan ubuntu image is no longer available, so running `vagrant up` in master branch errors out as follows:
```
The box 'ubuntu/eoan64' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Vagrant Cloud, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://vagrantcloud.com/ubuntu/eoan64"]
Error: The requested URL returned error: 404 Not Found
```

For the fix, I pointed to `ubuntu/focal64` and verified that `vagrant up` runs without error with the newer ubuntu image.