### PR TITLE
Update Vagrantfile to install Packer 1.7.3

### DIFF
--- a/provision-build-env.sh
+++ b/provision-build-env.sh
@@ -64,5 +64,5 @@ wget https://releases.hashicorp.com/packer/1.7.3/packer_1.7.3_linux_amd64.zip \
 cd /tmp
 unzip -u packer_1.7.3_linux_amd64.zip
 sudo cp packer /usr/local/bin
-rm -rf /tmp/packer*
+sudo rm -rf /tmp/packer*
 cd ..

--- a/provision-build-env.sh
+++ b/provision-build-env.sh
@@ -59,10 +59,10 @@ export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 # Download and install packer
 [[ -e /tmp/packer ]] && rm -rf /tmp/packer*
-wget https://releases.hashicorp.com/packer/1.5.2/packer_1.5.2_linux_amd64.zip \
-    -q -O /tmp/packer_1.5.2_linux_amd64.zip
+wget https://releases.hashicorp.com/packer/1.7.3/packer_1.7.3_linux_amd64.zip \
+    -q -O /tmp/packer_1.7.3_linux_amd64.zip
 cd /tmp
-unzip -u packer_1.5.2_linux_amd64.zip
+unzip -u packer_1.7.3_linux_amd64.zip
 sudo cp packer /usr/local/bin
 rm -rf /tmp/packer*
 cd ..

--- a/provision-build-image.sh
+++ b/provision-build-image.sh
@@ -15,21 +15,22 @@ PLUGIN_DIR=${PLUGIN_DIR:-/root/.packer.d/plugins}
 sudo mkdir -p $PLUGIN_DIR
 sudo cp /vagrant/packer-builder-arm-image "$PLUGIN_DIR/"
 # Now build the image
-if sudo [[ ! -f "$PLUGIN_DIR/packer-builder-arm-image" ]]; then {
+if sudo test ! -f "$PLUGIN_DIR/packer-builder-arm-image"; then {
     echo "Error: Plugin not found. Retry build."
     exit
 } else {
     echo "Attempting to build image"
 
     PACKER_LOG=$(mktemp)
+    export PACKER_CONFIG_DIR=/root/
 
     # If there is a custom json, try that one
     # otherwise go with the default
     if [[ -f /vagrant/${PACKERFILE} ]]; then {
-        sudo packer build /vagrant/${PACKERFILE} | tee ${PACKER_LOG}
+        sudo -E packer build /vagrant/${PACKERFILE} | tee ${PACKER_LOG}
     } else {
         if [[ -f $GOPATH/src/github.com/solo-io/packer-builder-arm-image/${PACKERFILE} ]]; then {
-            sudo packer build $GOPATH/src/github.com/solo-io/packer-builder-arm-image/${PACKERFILE} | tee ${PACKER_LOG}
+            sudo -E packer build $GOPATH/src/github.com/solo-io/packer-builder-arm-image/${PACKERFILE} | tee ${PACKER_LOG}
         } else {
             echo "Error: packer build definition ${PACKERFILE} not found."
             exit


### PR DESCRIPTION
Update Vagrantfile to install Packer 1.7.3.

This change also resolves several errors in the bash script which prevented the relevant commands from being executed.

Resolves #99