### PR TITLE
Support ubuntu images

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -252,6 +252,7 @@ func init() {
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
+	ui.Say(fmt.Sprintf("Image type: %s", b.config.ImageType))
 
 	wrappedCommand := func(command string) (string, error) {
 		b.config.ctx.Data = &wrappedCommandTemplate{Command: command}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -32,6 +32,7 @@ var (
 		utils.RaspberryPi: {"/boot", "/"},
 		utils.BeagleBone:  {"/"},
 		utils.Kali:        {"/root", "/"},
+		utils.Ubuntu:      {"/boot/firmware", "/"},
 	}
 	knownArgs = map[utils.KnownImageType][]string{
 		utils.BeagleBone: {"-cpu", "cortex-a8"},

--- a/pkg/image/utils/images.go
+++ b/pkg/image/utils/images.go
@@ -12,6 +12,7 @@ const (
 	RaspberryPi KnownImageType = "raspberrypi"
 	BeagleBone  KnownImageType = "beaglebone"
 	Kali        KnownImageType = "kali"
+	Ubuntu      KnownImageType = "ubuntu"
 	Unknown     KnownImageType = ""
 )
 
@@ -29,6 +30,10 @@ func GuessImageType(url string) KnownImageType {
 
 	if strings.Contains(url, "kali") {
 		return Kali
+	}
+
+	if strings.Contains(url, "ubuntu") {
+		return Ubuntu
 	}
 
 	return ""


### PR DESCRIPTION
This PR adds support for building Ubuntu ARM (hf or 64) images.

Additionally print the image type, so user can know if it was detected properly.