### PR TITLE
Use non-absolute path to udevadm

### DIFF
--- a/pkg/utils/devices.go
+++ b/pkg/utils/devices.go
@@ -80,7 +80,7 @@ type UdevAdm struct {
 
 func NewUdevAdm(name string) (*UdevAdm, error) {
 
-	data, err := exec.Command("/sbin/udevadm", "info", "--query=property", "--name="+name).Output()
+	data, err := exec.Command("udevadm", "info", "--query=property", "--name="+name).Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Without this change I get an error like that:
```
➜  packer/rpi2-ubuntu master ✗  sudo flasher
1. rpi2-ubuntu-20.04.img
Which image should we use (type number)? [rpi2-ubuntu-20.04.img] 
Using image: rpi2-ubuntu-20.04.img
error: fork/exec /sbin/udevadm: no such file or directory

```